### PR TITLE
add files property

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "tsc": "tsc",
     "test": "karma start"
   },
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/SamirHodzic/ngx-embed-video"


### PR DESCRIPTION
fix aot problems mentioned on #21 
As we can see on npm docs https://docs.npmjs.com/files/package.json#files

> `files field is an array of file patterns that describes the entries to be included when your package is installed as a dependency`

After this I could compile a build prod properly.

To test I've published 
`meumobi-ngx-embed-video@0.0.11` only adding files property.
I'will delete my package as soon my PR were merged
