### PR TITLE
get valid video_id from url which contain time.

### DIFF
--- a/src/embed-video.service.ts
+++ b/src/embed-video.service.ts
@@ -203,7 +203,13 @@ export class EmbedVideoService {
 
   private detectYoutube(url: any): string {
     if (url.hostname.indexOf('youtube.com') > -1) {
-      return url.search.split('=')[1];
+      var video_id = url.search.split('v=')[1];
+      var ampersandPosition = video_id.indexOf('&');
+      if(ampersandPosition != -1) {
+        video_id = video_id.substring(0, ampersandPosition);
+      }
+
+      return video_id;
     }
 
     if (url.hostname === 'youtu.be') {


### PR DESCRIPTION
There are few youtube urls contain time params like (https://www.youtube.com/watch?v=BwuLxPH8IDs&t=1910s) which not working in embedded, means it's contains some extra character with video_id which cause problem. To resolve this problem i provide a solution.